### PR TITLE
Return figure object from draw_network utility

### DIFF
--- a/fraud_analysis_graphml.py
+++ b/fraud_analysis_graphml.py
@@ -109,7 +109,7 @@ def draw_network(
         ),
     )
 
-    return fig.show()
+    return fig
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Fix draw_network to return the Plotly figure instead of the result of fig.show()

## Testing
- `python -m py_compile fraud_analysis_graphml.py`
- `python - <<'PY'
import pandas as pd
from fraud_analysis_graphml import draw_network
import plotly.graph_objs as go
sample_df = pd.DataFrame({'A':[1,2], 'B':[2,3]})
fig = draw_network(sample_df, 'A', 'B', sample=2)
print('Is figure:', isinstance(fig, go.Figure))
PY`


------
https://chatgpt.com/codex/tasks/task_e_689e19022db8832aafd2ed1cc9253689